### PR TITLE
fix: update Safari icon to use SVG format

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -19,7 +19,7 @@ async function getStaticAssets(context: Context): Promise<string[]> {
       fs.glob("_locales/*/messages.json", { cwd: srcDir }),
     )),
     ...(browser === "safari"
-      ? ["icons/template-icon-32.png"]
+      ? ["icons/template-icon.svg"]
       : ["icons/icon-32.png"]),
     "icons/icon-48.png",
     "icons/icon-128.png",

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -10,12 +10,10 @@ export function getManifest(context: ManifestContext) {
   const { browser, version, debug } = context;
   return {
     action: {
-      default_icon: {
-        32:
-          browser === "safari"
-            ? "icons/template-icon-32.png"
-            : "icons/icon-32.png",
-      },
+      default_icon:
+        browser === "safari"
+          ? "icons/template-icon.svg"
+          : { 32: "icons/icon-32.png" },
       default_popup: "pages/popup.html",
     },
 


### PR DESCRIPTION
This pull request updates the icon used for the Safari browser variant of the extension, switching from a PNG icon to an SVG icon for improved scalability and modern standards. The changes affect both the static asset build process and the browser manifest configuration.

**Safari icon update:**

* Updated the static asset list in `scripts/build.ts` to include `icons/template-icon.svg` instead of `icons/template-icon-32.png` when building for Safari.
* Modified the `default_icon` property in `src/manifest.ts` so that Safari uses `icons/template-icon.svg` rather than the PNG version, while other browsers continue to use the PNG icon.